### PR TITLE
Mark MKEPUG as archived and update information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# MKEPUG
+# MKEPUG (Archived)
 
-Milwaukee PHP User's Group. Interested? Check out the website at [http://mkepug.org](http://mkepug.org).
+Previous home of Milwaukee PHP User's Group. No longer active or maintained.
+
+Looking for Joel or Aaron? Check out [Mastering Laravel](https://masteringlaravel.io?ref=mkepug) instead.
 
 ## Deployment
 


### PR DESCRIPTION
Updated README to reflect that MKEPUG is archived and provided alternative resources.

Domains renewed for 5 more years each and auto-renew disabled.

<img width="870" height="146" alt="image" src="https://github.com/user-attachments/assets/c1b89b6c-4c32-447d-9b8a-c7f21fe6bc87" />
